### PR TITLE
Add timer module with basic get and set

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
- 
+use std::env;
 use std::path::PathBuf;
-use std::{env};
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(llvm_asm)]
 
 pub mod interrupt;
+pub mod timer;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,6 @@ pub unsafe fn set_vecbase(base: *const u32) {
     llvm_asm!("wsr.vecbase $0" ::"r"(base) :: "volatile");
 }
 
-/// Get the core cycle count
-#[inline]
-pub fn get_cycle_count() -> u32 {
-    let x: u32;
-    unsafe { llvm_asm!("rsr.ccount $0" : "=r"(x) ::: "volatile" ) };
-    x
-}
-
 /// Get the core stack pointer
 #[inline(always)]
 pub fn get_stack_pointer() -> *const u32 {
@@ -59,17 +51,6 @@ pub fn get_program_counter() -> *const u32 {
             " : "=r"(x),"=r"(_y)::"a0" : "volatile" )
     };
     x
-}
-
-/// cycle accurate delay using the cycle counter register
-#[inline]
-pub fn delay(clocks: u32) {
-    let start = get_cycle_count();
-    loop {
-        if get_cycle_count().wrapping_sub(start) >= clocks {
-            break;
-        }
-    }
 }
 
 /// Get the id of the current core

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -19,22 +19,22 @@ pub fn get_ccompare2() -> u32 {
 
 pub fn set_ccompare0(val: u32){
     unsafe { llvm_asm!("
-        movi a2,0
         wsr.ccompare0 $0
         isync
-        " :: "r"(val):"a2" ::: "volatile" ) };
+        " :: "r"(val):::: "volatile" ) 
+    };
 }
 pub fn set_ccompare1(val: u32){
     unsafe { llvm_asm!("
-        movi a2,0
         wsr.ccompare1 $0
         isync
-        " :: "r"(val):"a2" ::: "volatile" ) };
+        " :: "r"(val):::: "volatile" ) 
+    };
 }
 pub fn set_ccompare2(val: u32){
     unsafe { llvm_asm!("
-        movi a2,0
         wsr.ccompare2 $0
         isync
-        " :: "r"(val):"a2" ::: "volatile" ) };
+        " :: "r"(val):::: "volatile" ) 
+    };
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -20,27 +20,30 @@ pub fn get_ccompare2() -> u32 {
 }
 
 #[inline]
-pub fn set_ccompare0(val: u32){
-    unsafe { llvm_asm!("
+pub fn set_ccompare0(val: u32) {
+    unsafe {
+        llvm_asm!("
         wsr.ccompare0 $0
         isync
-        " :: "r"(val):::: "volatile" ) 
+        " :: "r"(val):::: "volatile" )
     };
 }
 #[inline]
-pub fn set_ccompare1(val: u32){
-    unsafe { llvm_asm!("
+pub fn set_ccompare1(val: u32) {
+    unsafe {
+        llvm_asm!("
         wsr.ccompare1 $0
         isync
-        " :: "r"(val):::: "volatile" ) 
+        " :: "r"(val):::: "volatile" )
     };
 }
 #[inline]
-pub fn set_ccompare2(val: u32){
-    unsafe { llvm_asm!("
+pub fn set_ccompare2(val: u32) {
+    unsafe {
+        llvm_asm!("
         wsr.ccompare2 $0
         isync
-        " :: "r"(val):::: "volatile" ) 
+        " :: "r"(val):::: "volatile" )
     };
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,22 +1,25 @@
 //! Xtensa internal timers
 
-
+#[inline]
 pub fn get_ccompare0() -> u32 {
     let x: u32;
     unsafe { llvm_asm!("rsr.ccompare0 $0" : "=r"(x) ::: "volatile" ) };
     x
 }
+#[inline]
 pub fn get_ccompare1() -> u32 {
     let x: u32;
     unsafe { llvm_asm!("rsr.ccompare1 $0" : "=r"(x) ::: "volatile" ) };
     x
 }
+#[inline]
 pub fn get_ccompare2() -> u32 {
     let x: u32;
     unsafe { llvm_asm!("rsr.ccompare2 $0" : "=r"(x) ::: "volatile" ) };
     x
 }
 
+#[inline]
 pub fn set_ccompare0(val: u32){
     unsafe { llvm_asm!("
         wsr.ccompare0 $0
@@ -24,6 +27,7 @@ pub fn set_ccompare0(val: u32){
         " :: "r"(val):::: "volatile" ) 
     };
 }
+#[inline]
 pub fn set_ccompare1(val: u32){
     unsafe { llvm_asm!("
         wsr.ccompare1 $0
@@ -31,10 +35,30 @@ pub fn set_ccompare1(val: u32){
         " :: "r"(val):::: "volatile" ) 
     };
 }
+#[inline]
 pub fn set_ccompare2(val: u32){
     unsafe { llvm_asm!("
         wsr.ccompare2 $0
         isync
         " :: "r"(val):::: "volatile" ) 
     };
+}
+
+/// Get the core cycle count
+#[inline]
+pub fn get_cycle_count() -> u32 {
+    let x: u32;
+    unsafe { llvm_asm!("rsr.ccount $0" : "=r"(x) ::: "volatile" ) };
+    x
+}
+
+/// cycle accurate delay using the cycle counter register
+#[inline]
+pub fn delay(clocks: u32) {
+    let start = get_cycle_count();
+    loop {
+        if get_cycle_count().wrapping_sub(start) >= clocks {
+            break;
+        }
+    }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,40 @@
+//! Xtensa internal timers
+
+
+pub fn get_ccompare0() -> u32 {
+    let x: u32;
+    unsafe { llvm_asm!("rsr.ccompare0 $0" : "=r"(x) ::: "volatile" ) };
+    x
+}
+pub fn get_ccompare1() -> u32 {
+    let x: u32;
+    unsafe { llvm_asm!("rsr.ccompare1 $0" : "=r"(x) ::: "volatile" ) };
+    x
+}
+pub fn get_ccompare2() -> u32 {
+    let x: u32;
+    unsafe { llvm_asm!("rsr.ccompare2 $0" : "=r"(x) ::: "volatile" ) };
+    x
+}
+
+pub fn set_ccompare0(val: u32){
+    unsafe { llvm_asm!("
+        movi a2,0
+        wsr.ccompare0 $0
+        isync
+        " :: "r"(val):"a2" ::: "volatile" ) };
+}
+pub fn set_ccompare1(val: u32){
+    unsafe { llvm_asm!("
+        movi a2,0
+        wsr.ccompare1 $0
+        isync
+        " :: "r"(val):"a2" ::: "volatile" ) };
+}
+pub fn set_ccompare2(val: u32){
+    unsafe { llvm_asm!("
+        movi a2,0
+        wsr.ccompare2 $0
+        isync
+        " :: "r"(val):"a2" ::: "volatile" ) };
+}


### PR DESCRIPTION
Simple control of the on chip timer peripherals.

These may need to be feature gated in the future as not all processors have all 3 timers.